### PR TITLE
Fixed requirements + readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ run::
 
     $ python setup.py install
 
-.. _compressed archive from PyPI: https://pypi.python.org/pypi/eureka-open
-.. _from Github: http://www.github.com/eureka-open
+.. _compressed archive from PyPI: https://pypi.python.org/pypi/eureka-opensource
+.. _from Github: https://github.com/solocalgroup/eureka-opensource
 
 I.5 Database creation
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ minify==0.1.4
 ecdsa==0.11
 paramiko==1.12.2
 
-pysqlite>=2.6.3
+pysqlite>=2.6.3,<2.8.0
 solrpy>=0.9.6
 Whoosh>=2.6


### PR DESCRIPTION
The Nagare command `create-db` was broken with `pysqlite >= 2.8.0`
I also fixed some links in the documentation